### PR TITLE
Fix voice messages processing

### DIFF
--- a/bot/add.go
+++ b/bot/add.go
@@ -68,6 +68,9 @@ func (b *Bot) onAddVoice(locale *i18n.Locale, message *telego.Message, arg strin
 		"-metadata", "album=Labrys",
 		"-metadata", "author=Labrys",
 		"-metadata", "title=@LabrysBot",
+		"-vn",
+		"-ac", "1",
+		"-ar", "48000",
 		"-c:a", "libopus",
 		temp,
 	)


### PR DESCRIPTION
A fix that:
- ignores the video stream in the input file (which could make the voice message impossible to play, more precisely, we can get the error 'first packet not flagged as BOS'),
- converts the sampling rate to 48000 Hz
- and makes a forced single-channel sound,

allowing us to guarantee that with any input file we will receive a working voice message with waveform.