### PR TITLE
Use stereo for voices

### DIFF
--- a/bot/add.go
+++ b/bot/add.go
@@ -69,7 +69,7 @@ func (b *Bot) onAddVoice(locale *i18n.Locale, message *telego.Message, arg strin
 		"-metadata", "author=Labrys",
 		"-metadata", "title=@LabrysBot",
 		"-vn",
-		"-ac", "1",
+		"-ac", "2",
 		"-ar", "48000",
 		"-c:a", "libopus",
 		temp,


### PR DESCRIPTION
This pull request is a continuation of https://github.com/altfoxie/labrys-bot/pull/1

- Nevertheless, it was decided to abandon the idea of forcing mono sound, since there are quite a lot of musical cuts in the bot that would sound better in stereo. It doesn't break waveforms and sound.
- It also turns out wasting bytes in cases where the input sound was originally in mono, but we believe that this is not so critical.